### PR TITLE
Minor updates for new package tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@ os:
   - linux
   - osx
 julia:
-  - 0.4
   - 0.5
+  - 0.6
+  - nightly
 notifications:
   email: false
 git:
@@ -13,9 +14,9 @@ git:
 
 ## uncomment the following lines to allow failures on nightly julia
 ## (tests will run but not make your overall status red)
-#matrix:
-#  allow_failures:
-#  - julia: nightly
+matrix:
+  allow_failures:
+  - julia: nightly
 
 ## uncomment and modify the following lines to manually install system packages
 #addons:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,10 @@ environment:
   matrix:
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
+matrix:
+  allow_failures:
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 


### PR DESCRIPTION
Ref https://github.com/JuliaLang/METADATA.jl/pull/10755

The package doesn't support Julia 0.4, so I've removed it from the Travis testing. I've also added Julia 0.6 to both Travis and AppVeyor. Rather than removing testing on nightly, I've set it up to test on nightly but allow failures. So even if something fails on 0.7, your overall build status on Travis won't be red.

Since the TimeIt package isn't registered, it can't be used as a testing requirement for a registered package. In fact, the author of TimeIt now recommends the BenchmarkTools package instead of TimeIt, so I've updated the testing code to use BenchmarkTools.

Lastly, all packages used for testing should be declared as dependencies in a test/REQUIRE file, so I've added such a file.